### PR TITLE
Update StringExtensions.swift to Swift 2.1

### DIFF
--- a/StringExtensions.swift
+++ b/StringExtensions.swift
@@ -31,15 +31,15 @@ extension String {
     /**
     Returns the length of the string.
     
-    :returns: Int length of the string.
+    - returns: Int length of the string.
     */
-
+    
     var length: Int {
-        return count(self)
+        return self.characters.count
     }
     
     var objcLength: Int {
-        return count(self.utf16)
+        return self.utf16.count
     }
     
     //MARK: - Linguistics
@@ -49,7 +49,7 @@ extension String {
     
     NOTE: String has to be at least 4 characters, otherwise the method will return nil.
     
-    :returns: String! Returns a string representing the langague of the string (e.g. en, fr, or und for undefined).
+    - returns: String! Returns a string representing the langague of the string (e.g. en, fr, or und for undefined).
     */
     func detectLanguage() -> String? {
         if self.length > 4 {
@@ -61,10 +61,10 @@ extension String {
     }
     
     /**
-    Returns the script of a String
-    
-    :returns: String! returns a string representing the script of the String (e.g. Latn, Hans).
-    */
+     Returns the script of a String
+     
+     - returns: String! returns a string representing the script of the String (e.g. Latn, Hans).
+     */
     func detectScript() -> String? {
         if self.length > 1 {
             let tagger = NSLinguisticTagger(tagSchemes:[NSLinguisticTagSchemeScript], options: 0)
@@ -75,13 +75,13 @@ extension String {
     }
     
     /**
-    Check the text direction of a given String.
-    
-    NOTE: String has to be at least 4 characters, otherwise the method will return false.
-    
-    :returns: Bool The Bool will return true if the string was writting in a right to left langague (e.g. Arabic, Hebrew)
-    
-    */
+     Check the text direction of a given String.
+     
+     NOTE: String has to be at least 4 characters, otherwise the method will return false.
+     
+     - returns: Bool The Bool will return true if the string was writting in a right to left langague (e.g. Arabic, Hebrew)
+     
+     */
     var isRightToLeft : Bool {
         let language = self.detectLanguage()
         return (language == "ar" || language == "he")
@@ -93,29 +93,29 @@ extension String {
     /**
     Check that a String is only made of white spaces, and new line characters.
     
-    :returns: Bool
+    - returns: Bool
     */
     func isOnlyEmptySpacesAndNewLineCharacters() -> Bool {
         return self.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()).length == 0
     }
     
     /**
-    Checks if a string is an email address using NSDataDetector.
-    
-    :returns: Bool
-    */
+     Checks if a string is an email address using NSDataDetector.
+     
+     - returns: Bool
+     */
     var isEmail: Bool {
-        let dataDetector = NSDataDetector(types: NSTextCheckingType.Link.rawValue, error: nil)
+        let dataDetector = try? NSDataDetector(types: NSTextCheckingType.Link.rawValue)
         let firstMatch = dataDetector?.firstMatchInString(self, options: NSMatchingOptions.ReportCompletion, range: NSMakeRange(0, length))
         
         return (firstMatch?.range.location != NSNotFound && firstMatch?.URL?.scheme == "mailto")
     }
     
     /**
-    Check that a String is 'tweetable' can be used in a tweet.
-    
-    :returns: Bool
-    */
+     Check that a String is 'tweetable' can be used in a tweet.
+     
+     - returns: Bool
+     */
     func isTweetable() -> Bool {
         let tweetLength = 140,
         // Each link takes 23 characters in a tweet (assuming all links are https).
@@ -125,36 +125,36 @@ extension String {
         if linksLength != 0 {
             return remaining < 0
         } else {
-            return !(count(self.utf16) > tweetLength || count(self.utf16) == 0 || self.isOnlyEmptySpacesAndNewLineCharacters())
+            return !(self.utf16.count > tweetLength || self.utf16.count == 0 || self.isOnlyEmptySpacesAndNewLineCharacters())
         }
     }
     
     /**
-    Gets an array of Strings for all links found in a String
-    
-    :returns: [String]
-    */
+     Gets an array of Strings for all links found in a String
+     
+     - returns: [String]
+     */
     func getLinks() -> [String] {
-        let detector = NSDataDetector(types: NSTextCheckingType.Link.rawValue, error: nil)
+        let detector = try? NSDataDetector(types: NSTextCheckingType.Link.rawValue)
         
-        let links = detector?.matchesInString(self, options: NSMatchingOptions.ReportCompletion, range: NSMakeRange(0, length)).map {$0 as! NSTextCheckingResult}
+        let links = detector?.matchesInString(self, options: NSMatchingOptions.ReportCompletion, range: NSMakeRange(0, length)).map {$0 }
         
         return links!.filter { link in
             return link.URL != nil
             }.map { link -> String in
-                return link.URL!.absoluteString!
+                return link.URL!.absoluteString
         }
     }
     
     /**
-    Gets an array of URLs for all links found in a String
-    
-    :returns: [NSURL]
-    */
+     Gets an array of URLs for all links found in a String
+     
+     - returns: [NSURL]
+     */
     func getURLs() -> [NSURL] {
-        let detector = NSDataDetector(types: NSTextCheckingType.Link.rawValue, error: nil)
+        let detector = try? NSDataDetector(types: NSTextCheckingType.Link.rawValue)
         
-        let links = detector?.matchesInString(self, options: NSMatchingOptions.ReportCompletion, range: NSMakeRange(0, length)).map {$0 as! NSTextCheckingResult}
+        let links = detector?.matchesInString(self, options: NSMatchingOptions.ReportCompletion, range: NSMakeRange(0, length)).map {$0 }
         
         return links!.filter { link in
             return link.URL != nil
@@ -165,14 +165,20 @@ extension String {
     
     
     /**
-    Gets an array of dates for all dates found in a String
-    
-    :returns: [NSDate]
-    */
+     Gets an array of dates for all dates found in a String
+     
+     - returns: [NSDate]
+     */
     func getDates() -> [NSDate] {
         let error: NSErrorPointer = NSErrorPointer()
-        let detector = NSDataDetector(types: NSTextCheckingType.Date.rawValue, error: error)
-        let dates = detector?.matchesInString(self, options: NSMatchingOptions.WithTransparentBounds, range: NSMakeRange(0, count(self.utf16))) .map {$0 as! NSTextCheckingResult}
+        let detector: NSDataDetector?
+        do {
+            detector = try NSDataDetector(types: NSTextCheckingType.Date.rawValue)
+        } catch let error1 as NSError {
+            error.memory = error1
+            detector = nil
+        }
+        let dates = detector?.matchesInString(self, options: NSMatchingOptions.WithTransparentBounds, range: NSMakeRange(0, self.utf16.count)) .map {$0 }
         
         return dates!.filter { date in
             return date.date != nil
@@ -182,13 +188,13 @@ extension String {
     }
     
     /**
-    Gets an array of strings (hashtags #acme) for all links found in a String
-    
-    :returns: [String]
-    */
+     Gets an array of strings (hashtags #acme) for all links found in a String
+     
+     - returns: [String]
+     */
     func getHashtags() -> [String]? {
-        let hashtagDetector = NSRegularExpression(pattern: "#(\\w+)", options: NSRegularExpressionOptions.CaseInsensitive, error: nil)
-        let results = hashtagDetector?.matchesInString(self, options: NSMatchingOptions.WithoutAnchoringBounds, range: NSMakeRange(0, count(self.utf16))).map { $0 as! NSTextCheckingResult }
+        let hashtagDetector = try? NSRegularExpression(pattern: "#(\\w+)", options: NSRegularExpressionOptions.CaseInsensitive)
+        let results = hashtagDetector?.matchesInString(self, options: NSMatchingOptions.WithoutAnchoringBounds, range: NSMakeRange(0, self.utf16.count)).map { $0 }
         
         return results?.map({
             (self as NSString).substringWithRange($0.rangeAtIndex(1))
@@ -196,24 +202,24 @@ extension String {
     }
     
     /**
-    Gets an array of distinct strings (hashtags #acme) for all hashtags found in a String
-    
-    :returns: [String]
-    */
+     Gets an array of distinct strings (hashtags #acme) for all hashtags found in a String
+     
+     - returns: [String]
+     */
     func getUniqueHashtags() -> [String]? {
         return Array(Set(getHashtags()!))
     }
-
+    
     
     
     /**
-    Gets an array of strings (mentions @apple) for all mentions found in a String
-    
-    :returns: [String]
-    */
+     Gets an array of strings (mentions @apple) for all mentions found in a String
+     
+     - returns: [String]
+     */
     func getMentions() -> [String]? {
-        let hashtagDetector = NSRegularExpression(pattern: "@(\\w+)", options: NSRegularExpressionOptions.CaseInsensitive, error: nil)
-        let results = hashtagDetector?.matchesInString(self, options: NSMatchingOptions.WithoutAnchoringBounds, range: NSMakeRange(0, count(self.utf16))).map { $0 as! NSTextCheckingResult }
+        let hashtagDetector = try? NSRegularExpression(pattern: "@(\\w+)", options: NSRegularExpressionOptions.CaseInsensitive)
+        let results = hashtagDetector?.matchesInString(self, options: NSMatchingOptions.WithoutAnchoringBounds, range: NSMakeRange(0, self.utf16.count)).map { $0 }
         
         return results?.map({
             (self as NSString).substringWithRange($0.rangeAtIndex(1))
@@ -221,61 +227,61 @@ extension String {
     }
     
     /**
-    Check if a String contains a Date in it.
-    
-    :returns: Bool with true value if it does
-    */
+     Check if a String contains a Date in it.
+     
+     - returns: Bool with true value if it does
+     */
     func getUniqueMentions() -> [String]? {
         return Array(Set(getMentions()!))
     }
     
     
     /**
-    Check if a String contains a link in it.
-    
-    :returns: Bool with true value if it does
-    */
+     Check if a String contains a link in it.
+     
+     - returns: Bool with true value if it does
+     */
     func containsLink() -> Bool {
         return self.getLinks().count > 0
     }
     
     /**
-    Check if a String contains a date in it.
-    
-    :returns: Bool with true value if it does
-    */
+     Check if a String contains a date in it.
+     
+     - returns: Bool with true value if it does
+     */
     func containsDate() -> Bool {
         return self.getDates().count > 0
     }
-
+    
     /**
-    :returns: Base64 encoded string
-    */
+     - returns: Base64 encoded string
+     */
     func encodeToBase64Encoding() -> String {
         let utf8str = self.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
         return utf8str.base64EncodedStringWithOptions(NSDataBase64EncodingOptions.Encoding64CharacterLineLength)
     }
     
     /**
-    :returns: Decoded Base64 string
-    */
+     - returns: Decoded Base64 string
+     */
     func decodeFromBase64Encoding() -> String {
         let base64data = NSData(base64EncodedString: self, options: NSDataBase64DecodingOptions.IgnoreUnknownCharacters)
         return NSString(data: base64data!, encoding: NSUTF8StringEncoding)! as String
     }
-
-
+    
+    
     
     // MARK: Subscript Methods
     
     subscript (i: Int) -> String {
-        return String(Array(self)[i])
+        return String(Array(self.characters)[i])
     }
     
     subscript (r: Range<Int>) -> String {
-        var start = advance(startIndex, r.startIndex),
-            end = advance(startIndex, r.endIndex)
-            
+        var start = startIndex.advancedBy(r.startIndex),
+        end = startIndex.advancedBy(r.endIndex)
+        
         return substringWithRange(Range(start: start, end: end))
     }
     


### PR DESCRIPTION
StringExtensions.swift is now compatible with Swift 2.1. Converted using Swift Migration Utility. 
Changes pertain to the new count attribute of strings, and the new error handling methods.