### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Swift String Tools
 A String extension that allows you to do some very awesome functions efforlessly. 
 
-###Functions
+### Functions
 Function Name | Description 
 --------------|------------
 ```var length``` | Length of String in Swift


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
